### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/rclone_python/rclone.py
+++ b/rclone_python/rclone.py
@@ -43,20 +43,6 @@ def about(remote_name: str):
 
     process = utils.run_cmd(f"rclone about {remote_name} --json")
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     if process.returncode == 0:
         return json.loads(process.stdout)
     else:


### PR DESCRIPTION
There appear to be some python formatting errors in d02fc9d5df21e0e193a9e39bfab97b93888b07d6. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.