### PR TITLE
Add support for the copyto and moveto commands

### DIFF
--- a/rclone_python/rclone.py
+++ b/rclone_python/rclone.py
@@ -141,7 +141,7 @@ def copy(
         in_path,
         out_path,
         ignore_existing=ignore_existing,
-        command="rclone copyto",
+        command="rclone copy",
         command_descr="Copying",
         show_progress=show_progress,
         listener=listener,

--- a/rclone_python/rclone.py
+++ b/rclone_python/rclone.py
@@ -149,6 +149,38 @@ def copy(
     )
 
 
+def copyto(
+    in_path: str,
+    out_path: str,
+    ignore_existing=False,
+    show_progress=True,
+    listener: Callable[[Dict], None] = None,
+    args=None,
+):
+    """
+    Copies a file or a directory from a src path to a destination path and is typically used when renaming a file is necessary.
+    :param in_path: The source path to use. Specify the remote with 'remote_name:path_on_remote'
+    :param out_path: The destination path to use. Specify the remote with 'remote_name:path_on_remote'
+    :param ignore_existing: If True, all existing files are ignored and not overwritten.
+    :param show_progress: If true, show a progressbar.
+    :param listener: An event-listener that is called with every update of rclone.
+    :param args: List of additional arguments/ flags.
+    """
+    if args is None:
+        args = []
+
+    _rclone_transfer_operation(
+        in_path,
+        out_path,
+        ignore_existing=ignore_existing,
+        command="rclone copyto",
+        command_descr="Copying",
+        show_progress=show_progress,
+        listener=listener,
+        args=args,
+    )
+
+
 def move(
     in_path: str,
     out_path: str,
@@ -174,6 +206,38 @@ def move(
         out_path,
         ignore_existing=ignore_existing,
         command="rclone move",
+        command_descr="Moving",
+        show_progress=show_progress,
+        listener=listener,
+        args=args,
+    )
+
+
+def moveto(
+    in_path: str,
+    out_path: str,
+    ignore_existing=False,
+    show_progress=True,
+    listener: Callable[[Dict], None] = None,
+    args=None,
+):
+    """
+    Moves a file or a directory from a src path to a destination path and is typically used when renaming is necessary.
+    :param in_path: The source path to use. Specify the remote with 'remote_name:path_on_remote'
+    :param out_path: The destination path to use. Specify the remote with 'remote_name:path_on_remote'
+    :param ignore_existing: If True, all existing files are ignored and not overwritten.
+    :param show_progress: If true, show a progressbar.
+    :param listener: An event-listener that is called with every update of rclone.
+    :param args: List of additional arguments/ flags.
+    """
+    if args is None:
+        args = []
+
+    _rclone_transfer_operation(
+        in_path,
+        out_path,
+        ignore_existing=ignore_existing,
+        command="rclone moveto",
         command_descr="Moving",
         show_progress=show_progress,
         listener=listener,


### PR DESCRIPTION
Besides the most commonly used `copy` and `move` commands, there is also the `copyto` and `moveto` commands. They are most typically used when renaming files/folders.

This PR adds these two commands as functions and also redefines the `copy` command (which was initially a `copyto`, as seen in 437d0d3707660d5b130366b5a55d007e8aba9223) to match with rclone's deninitions.