### PR TITLE
Change to fix the ValueError at the split

### DIFF
--- a/rclone_python/rclone.py
+++ b/rclone_python/rclone.py
@@ -519,7 +519,7 @@ def hash(
 
         for l in lines:
             if len(l) > 0:
-                value, key = l.split()
+                value, key = l.split("  ", maxsplit=1)
 
                 if checkfile is None:
                     hashsums[key] = value


### PR DESCRIPTION
If your folder that you were hashing, had files or folders with a space in their name, then this line of code will throw an error.

The code fixes it here by specifying the double space, and then a maxsplit=1 count to ensure that it only does the first double space, so if a folder or a file has a double space in the name they don't get split as well.

When using this in testing, this the error and I was unable to make another error with this.