### PR TITLE
Implement support for custom rclone config path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ rclone_python/__pycache__/
 rclone_python/scripts/__pycache__
 tests/__pycache__
 .vscode/
+*.conf

--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ print(rclone.check("data", "box:data"))
 (False, [('*', 'video1.webm'), ('=', 'video2.webm'), ('=', 'video2.webm')])
 ```
 
+### Custom config file
+You can define a custom file which rclone shall use by setting it up before running any command.
+Example with a config file named ".rclone.conf" in current working directory:
+```python
+import pathlib
+from rclone_python import rclone
+
+CONFIG_FILE = pathlib.Path(__file__).parent / ".rclone.conf"
+
+rclone.set_config_file(CONFIG_FILE)
+# All upcoming rclone commands will use custom config file
+```
+
 ## Custom Progressbar
 You can use your own rich progressbar with all transfer operations.
 This allows you to customize the columns to be displayed.

--- a/rclone_python/rclone.py
+++ b/rclone_python/rclone.py
@@ -25,6 +25,11 @@ def __check_installed(func):
     return wrapper
 
 
+def set_config_file(config_file: str):
+    """Change the config file used by this wrapper."""
+    utils.Config(config_file)
+
+
 def set_log_level(level: int):
     """Change the log level of this wrapper.
 

--- a/rclone_python/utils.py
+++ b/rclone_python/utils.py
@@ -41,9 +41,7 @@ class Config:
         return cls._instance
 
     def __init__(self, config_path: Union[str, Path] = None):
-        if self._initialized:
-            logger.warning("Config already initialized.")
-        else:
+        if not self._initialized:
             self.config_path = config_path
             self.__class__._initialized = True
 

--- a/rclone_python/utils.py
+++ b/rclone_python/utils.py
@@ -30,6 +30,7 @@ class RcloneException(ChildProcessError):
 
 class Config:
     """Config set up as singleton"""
+
     _instance = None
     _initialized = False
     config_path = None
@@ -127,6 +128,12 @@ def rclone_progress(
     total_progress_id = None
     subprocesses = {}
     errors = []
+
+    # Set the config path if defined by the user,
+    # otherwise the default rclone config path is used:
+    config = Config()
+    if config.config_path is not None:
+        command += f' --config="{config.config_path}"'
 
     if show_progress:
         if pbar is None:


### PR DESCRIPTION
Fixes #61 

This PR adds a Config class implemented as singleton, which can be used to define custom config path.
If set, the config path will be used when running rclone commands.

Added an entry in README.md to show usage.