### PR TITLE
fix: empty error message during failed transfer operation

### DIFF
--- a/rclone_python/utils.py
+++ b/rclone_python/utils.py
@@ -17,7 +17,8 @@ from rich.progress import (
 
 
 class RcloneException(ChildProcessError):
-    def __init__(self, description, error_msg):
+
+    def __init__(self, description: str, error_msg: str):
         self.description = description
         self.error_msg = error_msg
         super().__init__(f"{description}. Error message: \n{error_msg}")
@@ -189,11 +190,15 @@ def extract_rclone_progress(line: str) -> Tuple[bool, Union[Dict[str, Any], None
     Returns:
         Tuple[bool, Union[Dict[str, Any], None]]: The retrieved update Dictionary or error message.
     """
+    stats = None
 
     try:
         log_item: Dict = json.loads(line)
-        if log_item.get("level", None) == "error":
-            return False, log_item
+        level = log_item.get("level", None)
+        if level != "info":
+            if level in ("error", "critical"):
+                # return error message
+                return False, log_item
         else:
             # stats updates use the "info" level
             stats = log_item.get("stats", None)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -198,3 +198,15 @@ def test_progress_listener(tmp_remote_folder, tmp_local_folder, show_progress, m
     assert len(file_2_progress) > 0
     assert file_2_progress[0] == pytest.approx(0, abs=0.1)
     assert file_2_progress[-1] == pytest.approx(1)
+
+
+def test_rclone_transfer_operation_error_message(default_test_setup, tmp_local_folder):
+    faulty_remote_name = default_test_setup.remote_name + "s:"
+
+    try:        
+        rclone.copy(faulty_remote_name, tmp_local_folder)
+        assert False
+    except RcloneException as exception:
+        # check that a rclone exception message is set
+        assert len(exception.description) > 0
+        assert len(exception.error_msg) > 0


### PR DESCRIPTION
- fixes an error where rclone error messages were not displayed correctly after a failed transfer operation (e.g. copy from invalid remote name)