### PR TITLE
Switch logging to no longer write to root logger to avoid multiple log entries

### DIFF
--- a/rclone_python/logs.py
+++ b/rclone_python/logs.py
@@ -1,7 +1,12 @@
 import logging
 from rich.logging import RichHandler
 
+logger = logging.getLogger("rclone_python")
 
-FORMAT = "%(message)s"
-logging.basicConfig(format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
-logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = RichHandler()
+    handler.setFormatter(logging.Formatter("%(message)s", datefmt="[%X]"))
+    logger.addHandler(handler)
+
+logger.setLevel(logging.INFO)
+logger.propagate = False


### PR DESCRIPTION
When using this project as a package in a project that also uses pythons `logging` API, calling e.g. `logging.info()` leads to multiple log entries both by the main project's logger, as well as by `rclone_python`s logger. This is due to the logger being registered using `logging.basicConfig()`, which registers a logging handle at root level.

The [python docs](https://docs.python.org/3/library/logging.html#logging.basicConfig) claim about `basicConfig`:
> This function does nothing if the root logger already has handlers configured, unless the keyword argument force is set to True.

But because the code in `rclone_python/logs.py` gets executed during package import, this is quite likely to not be the case when importing rclone at the top of a file.

This PR proposes a low profile fix: Instead of registering a logger at root level using `basicConfig()`, which comes with the issue named above, a logger named `rclone_python` gets created with the appropriate settings and propagation set to `False`, so the root logger of any importing script does not get spammed by this package's outputs and this package retains control over its own outputs. The rest of the package's interface remains unchanged.